### PR TITLE
Escapes regex double braces (increases compatibility)

### DIFF
--- a/jquery.blast.js
+++ b/jquery.blast.js
@@ -81,7 +81,7 @@
 
         /* Used to decode both the output of encodePunctuation() and punctuation that has been manually escaped by users. */
         function decodePunctuation (text) {
-            return text.replace(/{{(\d{1,3})}}/g, function(fullMatch, subMatch) {
+            return text.replace(/\{\{(\d{1,3})\}\}/g, function(fullMatch, subMatch) {
                 return String.fromCharCode(subMatch);
             }); 
         }


### PR DESCRIPTION
I have run into compatibility issues when integrating Blast into a Jekyll project, due to a regular expression with unescaped double curly braces (`{{` and `}}`). While it's generally accepted not to escape curly braces, [doing it doesn't harm and it widens](http://www.regular-expressions.info/characters.html) Blast to integrate with other projects and build tools such as the aforementioned.